### PR TITLE
validar tentar cadastrar com nome e senha validos e email vazio

### DIFF
--- a/cypress/e2e/qazando/cadastro-usuario/registrar-usuario-falha.cy.js
+++ b/cypress/e2e/qazando/cadastro-usuario/registrar-usuario-falha.cy.js
@@ -79,4 +79,22 @@ describe("Validação de erros no cadastro de usuário", () => {
             .should('be.visible')
             .should('contain.text', 'O campo e-mail deve ser prenchido corretamente');
     });
+
+    it("Deve exibir erro ao tentar cadastrar com Nome e Senha preenchidos, mas E-mail vazio", () => {
+        cy.get(elementos.fields.name)
+            .should('be.visible')
+            .type(faker.person.fullName())
+
+        cy.get(elementos.fields.password)
+            .should('be.visible')
+            .type(faker.internet.password({ length: 6 }))
+
+        cy.get(elementos.buttons.register)
+            .should('be.visible')
+            .click()
+
+        cy.get(elementos.messages.error)
+            .should('be.visible')
+            .should('contain.text', 'O campo e-mail deve ser prenchido corretamente');
+    });
 });


### PR DESCRIPTION
Valida a tentativa de cadastrar um usuário enviando nome e senha válidos, mas o campo email vazio